### PR TITLE
Start setting the baseMediaDecodeTime in fragments

### DIFF
--- a/lib/mp4-generator.js
+++ b/lib/mp4-generator.js
@@ -540,9 +540,7 @@ tkhd = function(track) {
  */
 traf = function(track) {
   var trackFragmentHeader, trackFragmentDecodeTime,
-      trackFragmentRun, sampleDependencyTable, dataOffset,
-      baseMediaDecodeTime,
-      scale;
+      trackFragmentRun, sampleDependencyTable, dataOffset;
 
   trackFragmentHeader = box(types.tfhd, new Uint8Array([
     0x00, // version 0
@@ -557,26 +555,14 @@ traf = function(track) {
     0x00, 0x00, 0x00, 0x00  // default_sample_flags
   ]));
 
-  baseMediaDecodeTime = track.minPTS - track.earliestPTS;
-
-  if (track.type === 'audio') {
-    scale = track.samplerate / 90000;
-    // Audio has a different clock equal to the sample rate so we need to
-    // scale the PTS values into the clock rate of the track
-    baseMediaDecodeTime = scale * track.minPTS - scale * track.earliestPTS;
-    baseMediaDecodeTime = Math.floor(baseMediaDecodeTime);
-//    console.log('audio', track.earliestPTS, track.minPTS, track.maxPTS, '>>', (track.samplerate / 90000 * track.earliestPTS), (track.samplerate / 90000 * track.minPTS), (track.samplerate / 90000 * track.maxPTS), baseMediaDecodeTime);
-  } else {
-//    console.log('video', track.earliestPTS, track.minPTS, track.maxPTS, baseMediaDecodeTime);
-  }
   trackFragmentDecodeTime = box(types.tfdt, new Uint8Array([
     0x00, // version 0
     0x00, 0x00, 0x00, // flags
     // baseMediaDecodeTime
-    (baseMediaDecodeTime >>> 24) & 0xFF,
-    (baseMediaDecodeTime >>> 16) & 0xFF,
-    (baseMediaDecodeTime >>> 8) & 0xFF,
-    baseMediaDecodeTime & 0xFF
+    (track.baseMediaDecodeTime >>> 24) & 0xFF,
+    (track.baseMediaDecodeTime >>> 16) & 0xFF,
+    (track.baseMediaDecodeTime >>> 8) & 0xFF,
+    track.baseMediaDecodeTime & 0xFF
   ]));
 
   // the data offset specifies the number of bytes from the start of

--- a/lib/mp4-generator.js
+++ b/lib/mp4-generator.js
@@ -234,7 +234,7 @@ mdhd = function(track) {
     0x00, 0x00, 0x00, 0x03, // modification_time
     0x00, 0x01, 0x5f, 0x90, // timescale, 90,000 "ticks" per second
 
-    (track.duration >>> 24),
+    (track.duration >>> 24) & 0xFF,
     (track.duration >>> 16) & 0xFF,
     (track.duration >>>  8) & 0xFF,
     track.duration & 0xFF,  // duration
@@ -246,11 +246,12 @@ mdhd = function(track) {
   // defined. The sample rate can be parsed out of an ADTS header, for
   // instance.
   if (track.samplerate) {
-    result[12] = (track.samplerate >>> 24);
+    result[12] = (track.samplerate >>> 24) & 0xFF;
     result[13] = (track.samplerate >>> 16) & 0xFF;
     result[14] = (track.samplerate >>>  8) & 0xFF;
     result[15] = (track.samplerate)        & 0xFF;
   }
+
   return box(types.mdhd, result);
 };
 mdia = function(track) {
@@ -539,7 +540,9 @@ tkhd = function(track) {
  */
 traf = function(track) {
   var trackFragmentHeader, trackFragmentDecodeTime,
-      trackFragmentRun, sampleDependencyTable, dataOffset;
+      trackFragmentRun, sampleDependencyTable, dataOffset,
+      baseMediaDecodeTime,
+      scale;
 
   trackFragmentHeader = box(types.tfhd, new Uint8Array([
     0x00, // version 0
@@ -554,10 +557,26 @@ traf = function(track) {
     0x00, 0x00, 0x00, 0x00  // default_sample_flags
   ]));
 
+  baseMediaDecodeTime = track.minPTS - track.earliestPTS;
+
+  if (track.type === 'audio') {
+    scale = track.samplerate / 90000;
+    // Audio has a different clock equal to the sample rate so we need to
+    // scale the PTS values into the clock rate of the track
+    baseMediaDecodeTime = scale * track.minPTS - scale * track.earliestPTS;
+    baseMediaDecodeTime = Math.floor(baseMediaDecodeTime);
+//    console.log('audio', track.earliestPTS, track.minPTS, track.maxPTS, '>>', (track.samplerate / 90000 * track.earliestPTS), (track.samplerate / 90000 * track.minPTS), (track.samplerate / 90000 * track.maxPTS), baseMediaDecodeTime);
+  } else {
+//    console.log('video', track.earliestPTS, track.minPTS, track.maxPTS, baseMediaDecodeTime);
+  }
   trackFragmentDecodeTime = box(types.tfdt, new Uint8Array([
     0x00, // version 0
     0x00, 0x00, 0x00, // flags
-    0x00, 0x00, 0x00, 0x00 // baseMediaDecodeTime
+    // baseMediaDecodeTime
+    (baseMediaDecodeTime >>> 24) & 0xFF,
+    (baseMediaDecodeTime >>> 16) & 0xFF,
+    (baseMediaDecodeTime >>> 8) & 0xFF,
+    baseMediaDecodeTime & 0xFF
   ]));
 
   // the data offset specifies the number of bytes from the start of

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -89,6 +89,7 @@
     this.on('data', function(data) {
       destination.push(data);
     });
+    return destination;
   };
 
   window.muxjs = window.muxjs || {};

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -464,6 +464,7 @@ AacStream = function() {
 
       // deliver the AAC frame
       this.trigger('data', {
+        pts: packet.pts,
         audioobjecttype: ((buffer[i + 1] >>> 6) & 0x03) + 1,
         channelcount: ((buffer[i + 1] & 1) << 3) |
           ((buffer[i + 2] & 0xc0) >>> 6),
@@ -493,6 +494,26 @@ AudioSegmentStream = function(track) {
   AudioSegmentStream.prototype.init.call(this);
 
   this.push = function(data) {
+    if (track.minPTS === undefined) {
+      track.minPTS = data.pts;
+    } else {
+      track.minPTS = Math.min(track.minPTS, data.pts);
+    }
+
+    if (track.maxPTS === undefined) {
+      track.maxPTS = data.pts;
+    } else {
+      track.maxPTS = Math.max(track.maxPTS, data.pts);
+    }
+
+    if (track && track.channelcount === undefined) {
+      track.audioobjecttype = data.audioobjecttype;
+      track.channelcount = data.channelcount;
+      track.samplerate = data.samplerate;
+      track.samplingfrequencyindex = data.samplingfrequencyindex;
+      track.samplesize = data.samplesize;
+    }
+
     // buffer audio data until end() is called
     aacFrames.push(data);
     aacFramesLength += data.data.byteLength;
@@ -902,10 +923,45 @@ VideoSegmentStream = function(track) {
   var
     sequenceNumber = 0,
     nalUnits = [],
-    nalUnitsLength = 0;
+    nalUnitsLength = 0,
+    config,
+    pps;
   VideoSegmentStream.prototype.init.call(this);
 
+  delete track.minPTS;
+
   this.push = function(data) {
+    if (track.minPTS === undefined) {
+      track.minPTS = data.pts;
+    } else {
+      track.minPTS = Math.min(track.minPTS, data.pts);
+    }
+
+    if (track.maxPTS === undefined) {
+      track.maxPTS = data.pts;
+    } else {
+      track.maxPTS = Math.max(track.maxPTS, data.pts);
+    }
+
+    // record the track config
+    if (data.nalUnitType === 'seq_parameter_set_rbsp' &&
+        !config) {
+      config = data.config;
+
+      track.width = config.width;
+      track.height = config.height;
+      track.sps = [data.data];
+      track.profileIdc = config.profileIdc;
+      track.levelIdc = config.levelIdc;
+      track.profileCompatibility = config.profileCompatibility;
+    }
+
+    if (data.nalUnitType === 'pic_parameter_set_rbsp' &&
+        !pps) {
+      pps = data.data;
+      track.pps = [data.data];
+    }
+
     // buffer video until end() is called
     nalUnits.push(data);
     nalUnitsLength += data.data.byteLength;
@@ -1009,8 +1065,7 @@ Transmuxer = function() {
     self = this,
     videoTrack,
     audioTrack,
-    config,
-    pps,
+    earliestPTS,
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
@@ -1029,43 +1084,15 @@ Transmuxer = function() {
   this.metadataStream = new muxjs.mp2t.MetadataStream();
 
   // assemble MPEG2-TS packets into elementary streams
-  packetStream.pipe(parseStream);
-  parseStream.pipe(elementaryStream);
+  packetStream
+    .pipe(parseStream)
+    .pipe(elementaryStream);
+
   // remux the streams
   elementaryStream.pipe(aacStream);
   elementaryStream.pipe(h264Stream);
   elementaryStream.pipe(this.metadataStream);
 
-  // handle incoming data events
-  h264Stream.on('data', function(data) {
-    // record the track config
-    if (data.nalUnitType === 'seq_parameter_set_rbsp' &&
-        !config) {
-      config = data.config;
-
-      videoTrack.width = config.width;
-      videoTrack.height = config.height;
-      videoTrack.sps = [data.data];
-      videoTrack.profileIdc = config.profileIdc;
-      videoTrack.levelIdc = config.levelIdc;
-      videoTrack.profileCompatibility = config.profileCompatibility;
-    }
-    if (data.nalUnitType === 'pic_parameter_set_rbsp' &&
-        !pps) {
-      pps = data.data;
-      videoTrack.pps = [data.data];
-    }
-  });
-  // generate an init segment based on the first audio sample
-  aacStream.on('data', function(data) {
-    if (audioTrack && audioTrack.channelcount === undefined) {
-      audioTrack.audioobjecttype = data.audioobjecttype;
-      audioTrack.channelcount = data.channelcount;
-      audioTrack.samplerate = data.samplerate;
-      audioTrack.samplingfrequencyindex = data.samplingfrequencyindex;
-      audioTrack.samplesize = data.samplesize;
-    }
-  });
   // hook up the segment streams once track metadata is delivered
   elementaryStream.on('data', function(data) {
     var triggerData = function(type) {
@@ -1073,7 +1100,10 @@ Transmuxer = function() {
       return function(mediaData) {
         // append the media data to an init segment
         var
-          initSegment = muxjs.mp4.initSegment([track]),
+          initSegment,
+          segment;
+
+          initSegment = muxjs.mp4.initSegment([track]);
           segment = new Uint8Array(initSegment.byteLength +
                                    mediaData.byteLength);
         segment.set(initSegment);
@@ -1084,6 +1114,15 @@ Transmuxer = function() {
         });
       };
     }, i;
+
+    if (data.type === 'audio' || data.type === 'video') {
+      if (earliestPTS === undefined) {
+        earliestPTS = data.pts;
+      } else {
+        earliestPTS = Math.min(earliestPTS, data.pts);
+      }
+    }
+
     if (data.type === 'metadata') {
       i = data.tracks.length;
 
@@ -1112,16 +1151,21 @@ Transmuxer = function() {
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
+    videoSegmentStream = null;
+    audioSegmentStream = null;
     packetStream.push(data);
   };
+
   // flush any buffered data
   this.flush = function() {
     elementaryStream.flush();
     h264Stream.flush();
     if (videoSegmentStream) {
+      videoTrack.earliestPTS = earliestPTS;
       videoSegmentStream.flush();
     }
     if (audioSegmentStream) {
+      audioTrack.earliestPTS = earliestPTS;
       audioSegmentStream.flush();
     }
     // Let the consumer know we have finished flushing the buffers

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -17,7 +17,7 @@ var TransportPacketStream, TransportParseStream, ElementaryStream,
     H264Stream, NalByteStream;
 
 // Helper functions
-var collectDTSInfo, clearDTSInfo, calculateTrackBMDT;
+var collectDTSInfo, clearDTSInfo, calculateTrackBaseMediaDecodeTime;
 
 // constants
 var MP2T_PACKET_LENGTH, H264_STREAM_TYPE, ADTS_STREAM_TYPE,
@@ -539,7 +539,7 @@ AudioSegmentStream = function(track) {
     aacFramesLength = 0;
     mdat = mp4.mdat(data);
 
-    calculateTrackBMDT(track);
+    calculateTrackBaseMediaDecodeTime(track);
     moof = mp4.moof(sequenceNumber, [track]);
     boxes = new Uint8Array(moof.byteLength + mdat.byteLength);
 
@@ -1022,7 +1022,7 @@ VideoSegmentStream = function(track) {
     nalUnitsLength = 0;
     mdat = mp4.mdat(data);
 
-    calculateTrackBMDT(track);
+    calculateTrackBaseMediaDecodeTime(track);
 
     moof = mp4.moof(sequenceNumber, [track]);
 
@@ -1042,6 +1042,11 @@ VideoSegmentStream = function(track) {
 };
 VideoSegmentStream.prototype = new muxjs.Stream();
 
+/**
+ * Store information about the start and end of the tracka and the
+ * duration for each frame/sample we process in order to calculate
+ * the baseMediaDecodeTime
+ */
 collectDTSInfo = function (track, data) {
   if (track.minDTS === undefined) {
     track.minDTS = data.dts;
@@ -1052,6 +1057,11 @@ collectDTSInfo = function (track, data) {
   if (track.maxDTS === undefined) {
     track.maxDTS = data.dts;
   } else {
+    // In order to calculate the "duration" of samples we look for
+    // the last sample that has a duration longer than an arbitrary
+    // value of "100."
+    // The reason is that often the last sample has a tiny duration
+    // that is not indicative of the true duration of the samples
     if (data.dts - track.maxDTS > 100) {
       track.deltaDTS = data.dts - track.maxDTS;
     }
@@ -1059,36 +1069,48 @@ collectDTSInfo = function (track, data) {
   }
 };
 
+/**
+ * Clear values used to calculate the baseMediaDecodeTime between
+ * tracks
+ */
 clearDTSInfo = function (track) {
   delete track.minDTS;
   delete track.maxDTS;
   delete track.deltaDTS;
 };
 
-calculateTrackBMDT = function (track) {
-  var scale;
-  var nextExpectedBMDT = track.nextExpectedBMDT;
+/**
+ * Calculate the track's baseMediaDecodeTime based on the earliest
+ * DTS the transmuxer has ever seen and the minimum DTS for the
+ * current track
+ */
+calculateTrackBaseMediaDecodeTime = function (track) {
+  var
+    expectedBaseMediaDecodeTime = track.expectedBaseMediaDecodeTime,
+    oneSecondInPTS = 90000, // 90kHz clock
+    scale;
 
   track.baseMediaDecodeTime = track.minDTS - track.earliestDTS;
 
-  if (nextExpectedBMDT) {
+  if (expectedBaseMediaDecodeTime) {
     // We arbitrarily decide that if the difference is greater than one
-    // second we should not attempt to "pull in" the segment in time
-    if (nextExpectedBMDT < track.baseMediaDecodeTime &&
-      track.baseMediaDecodeTime - nextExpectedBMDT < 90000) {
-      track.baseMediaDecodeTime = nextExpectedBMDT;
+    // second we should NOT attempt to place the segment directly after
+    // the last
+    if (expectedBaseMediaDecodeTime < track.baseMediaDecodeTime &&
+      track.baseMediaDecodeTime - expectedBaseMediaDecodeTime < oneSecondInPTS) {
+      track.baseMediaDecodeTime = expectedBaseMediaDecodeTime;
     }
   }
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
     // scale the PTS values into the clock rate of the track
-    scale = track.samplerate / 90000;
+    scale = track.samplerate / oneSecondInPTS;
     track.baseMediaDecodeTime *= scale;
     track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
   }
 
-  track.nextExpectedBMDT = track.deltaDTS + track.maxDTS - track.earliestDTS;
+  track.expectedBaseMediaDecodeTime = track.deltaDTS + track.maxDTS - track.earliestDTS;
 };
 
 /**
@@ -1106,28 +1128,27 @@ Transmuxer = function() {
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
-    videoSegmentStream, audioSegmentStream;
+    videoSegmentStream, audioSegmentStream,
+    dataEmitterStream = {
+      push: function(output) {
+        // append the media data to an init segment
+        var
+          track = output.track,
+          mediaData = output.boxes,
+          initSegment,
+          segment;
 
-  this.dataEmitter = {
-    push: function(output) {
-      // append the media data to an init segment
-      var
-        track = output.track,
-        mediaData = output.boxes,
-        initSegment,
-        segment;
-
-        initSegment = muxjs.mp4.initSegment([track]);
-        segment = new Uint8Array(initSegment.byteLength +
-                                 mediaData.byteLength);
-      segment.set(initSegment);
-      segment.set(mediaData, initSegment.byteLength);
-      self.trigger('data', {
-        type: track.type,
-        data: segment
-      });
-    }
-  };
+          initSegment = muxjs.mp4.initSegment([track]);
+          segment = new Uint8Array(initSegment.byteLength +
+                                   mediaData.byteLength);
+        segment.set(initSegment);
+        segment.set(mediaData, initSegment.byteLength);
+        self.trigger('data', {
+          type: track.type,
+          data: segment
+        });
+      }
+    };
 
   Transmuxer.prototype.init.call(this);
 
@@ -1175,14 +1196,14 @@ Transmuxer = function() {
           videoSegmentStream = new VideoSegmentStream(videoTrack);
           h264Stream
             .pipe(videoSegmentStream)
-            .pipe(self.dataEmitter);
+            .pipe(dataEmitterStream);
         } else if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
           // hook up the audio segment stream to the first track with aac data
           audioTrack = data.tracks[i];
           audioSegmentStream = new AudioSegmentStream(audioTrack);
           aacStream
             .pipe(audioSegmentStream)
-            .pipe(self.dataEmitter);
+            .pipe(dataEmitterStream);
         }
       }
     }

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -492,7 +492,7 @@ AacStream.prototype = new muxjs.Stream();
  * configured with a suitable initialization segment.
  */
 // TODO: share common code with VideoSegmentStream
-AudioSegmentStream = function(track, emitData) {
+AudioSegmentStream = function(track) {
   var aacFrames = [], aacFramesLength = 0, sequenceNumber = 0;
   AudioSegmentStream.prototype.init.call(this);
 
@@ -550,7 +550,7 @@ AudioSegmentStream = function(track, emitData) {
     boxes.set(mdat, moof.byteLength);
 
     clearDTSInfo(track);
-    emitData(track, boxes);
+    this.trigger('data', {track: track, boxes: boxes});
   };
 };
 AudioSegmentStream.prototype = new muxjs.Stream();
@@ -914,7 +914,7 @@ H264Stream.prototype = new muxjs.Stream();
  * configured with a suitable initialization segment.
  * @param track {object} track metadata configuration
  */
-VideoSegmentStream = function(track, emitData) {
+VideoSegmentStream = function(track) {
   var
     sequenceNumber = 0,
     nalUnits = [],
@@ -1037,7 +1037,7 @@ VideoSegmentStream = function(track, emitData) {
     boxes.set(mdat, moof.byteLength);
 
     clearDTSInfo(track);
-    emitData(track, boxes);
+    this.trigger('data', {track: track, boxes: boxes});
   };
 };
 VideoSegmentStream.prototype = new muxjs.Stream();
@@ -1110,11 +1110,14 @@ Transmuxer = function() {
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
-    videoSegmentStream, audioSegmentStream,
+    videoSegmentStream, audioSegmentStream;
 
-    emitData = function(track, mediaData) {
+  this.dataEmitter = {
+    push: function(output) {
       // append the media data to an init segment
       var
+        track = output.track,
+        mediaData = output.boxes,
         initSegment,
         segment;
 
@@ -1127,7 +1130,8 @@ Transmuxer = function() {
         type: track.type,
         data: segment
       });
-    };
+    }
+  };
 
   Transmuxer.prototype.init.call(this);
 
@@ -1172,16 +1176,17 @@ Transmuxer = function() {
         // hook up the video segment stream to the first track with h264 data
         if (data.tracks[i].type === 'video' && !videoSegmentStream) {
           videoTrack = data.tracks[i];
-          videoSegmentStream = new VideoSegmentStream(videoTrack, emitData);
-          h264Stream.pipe(videoSegmentStream);
-          break;
-        }
-
-        // hook up the audio segment stream to the first track with aac data
-        if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
+          videoSegmentStream = new VideoSegmentStream(videoTrack);
+          h264Stream
+            .pipe(videoSegmentStream)
+            .pipe(self.dataEmitter);
+        } else if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
+          // hook up the audio segment stream to the first track with aac data
           audioTrack = data.tracks[i];
-          audioSegmentStream = new AudioSegmentStream(audioTrack, emitData);
-          aacStream.pipe(audioSegmentStream);
+          audioSegmentStream = new AudioSegmentStream(audioTrack);
+          aacStream
+            .pipe(audioSegmentStream)
+            .pipe(self.dataEmitter);
         }
       }
     }

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -446,7 +446,7 @@ AacStream = function() {
   self = this;
 
   this.push = function(packet) {
-    var frameLength;
+    var frameLength, protectionSkip;
 
     if (packet.type !== 'audio') {
       // ignore non-audio data
@@ -455,10 +455,10 @@ AacStream = function() {
 
     buffer = packet.data;
 
-
     // unpack any ADTS frames which have been fully received
     // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
     while (i + 4 < buffer.length) {
+      protectionSkip = (~buffer[i] & 0x01) * 2;
       // frame length is a 13 bit integer starting 16 bits from the
       // end of the sync sequence
       frameLength = ((buffer[i + 2] & 0x03) << 11) |
@@ -467,7 +467,7 @@ AacStream = function() {
 
       // deliver the AAC frame
       this.trigger('data', {
-        pts: packet.pts,
+        dts: packet.dts,
         audioobjecttype: ((buffer[i + 1] >>> 6) & 0x03) + 1,
         channelcount: ((buffer[i + 1] & 1) << 3) |
           ((buffer[i + 2] & 0xc0) >>> 6),
@@ -475,7 +475,7 @@ AacStream = function() {
         samplingfrequencyindex: (buffer[i + 1] & 0x3c) >>> 2,
         // assume ISO/IEC 14496-12 AudioSampleEntry default of 16
         samplesize: 16,
-        data: buffer.subarray(i + 6, i + frameLength - 1)
+        data: buffer.subarray(i + 6 + protectionSkip, i + frameLength - 1)
       });
 
       // flush the finished frame and try again

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -1081,15 +1081,11 @@ calculateTrackBMDT = function (track) {
   }
 
   if (track.type === 'audio') {
-    console.log('audio', track.earliestDTS, track.minDTS, track.maxDTS, track.deltaDTS, track.endDTS, track.baseMediaDecodeTime);
     // Audio has a different clock equal to the sampling_rate so we need to
     // scale the PTS values into the clock rate of the track
     scale = track.samplerate / 90000;
     track.baseMediaDecodeTime *= scale;
     track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
-    console.log('audio >>', (track.samplerate / 90000 * track.earliestDTS), (track.samplerate / 90000 * track.minDTS), (track.samplerate / 90000 * track.maxDTS), track.baseMediaDecodeTime);
-  } else {
-    console.log('video', track.earliestDTS, track.minDTS, track.maxDTS, track.deltaDTS, track.endDTS, track.baseMediaDecodeTime);
   }
 
   track.nextExpectedBMDT = track.deltaDTS + track.maxDTS - track.earliestDTS;

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -16,6 +16,9 @@ var TransportPacketStream, TransportParseStream, ElementaryStream,
     VideoSegmentStream, AudioSegmentStream, Transmuxer, AacStream,
     H264Stream, NalByteStream;
 
+// Helper functions
+var collectDTSInfo, clearDTSInfo, calculateTrackBMDT;
+
 // constants
 var MP2T_PACKET_LENGTH, H264_STREAM_TYPE, ADTS_STREAM_TYPE,
     METADATA_STREAM_TYPE, ADTS_SAMPLING_FREQUENCIES;
@@ -489,22 +492,12 @@ AacStream.prototype = new muxjs.Stream();
  * configured with a suitable initialization segment.
  */
 // TODO: share common code with VideoSegmentStream
-AudioSegmentStream = function(track) {
+AudioSegmentStream = function(track, emitData) {
   var aacFrames = [], aacFramesLength = 0, sequenceNumber = 0;
   AudioSegmentStream.prototype.init.call(this);
 
   this.push = function(data) {
-    if (track.minPTS === undefined) {
-      track.minPTS = data.pts;
-    } else {
-      track.minPTS = Math.min(track.minPTS, data.pts);
-    }
-
-    if (track.maxPTS === undefined) {
-      track.maxPTS = data.pts;
-    } else {
-      track.maxPTS = Math.max(track.maxPTS, data.pts);
-    }
+    collectDTSInfo(track, data);
 
     if (track && track.channelcount === undefined) {
       track.audioobjecttype = data.audioobjecttype;
@@ -546,6 +539,7 @@ AudioSegmentStream = function(track) {
     aacFramesLength = 0;
     mdat = mp4.mdat(data);
 
+    calculateTrackBMDT(track);
     moof = mp4.moof(sequenceNumber, [track]);
     boxes = new Uint8Array(moof.byteLength + mdat.byteLength);
 
@@ -555,7 +549,8 @@ AudioSegmentStream = function(track) {
     boxes.set(moof);
     boxes.set(mdat, moof.byteLength);
 
-    this.trigger('data', boxes);
+    clearDTSInfo(track);
+    emitData(track, boxes);
   };
 };
 AudioSegmentStream.prototype = new muxjs.Stream();
@@ -919,7 +914,7 @@ H264Stream.prototype = new muxjs.Stream();
  * configured with a suitable initialization segment.
  * @param track {object} track metadata configuration
  */
-VideoSegmentStream = function(track) {
+VideoSegmentStream = function(track, emitData) {
   var
     sequenceNumber = 0,
     nalUnits = [],
@@ -931,17 +926,7 @@ VideoSegmentStream = function(track) {
   delete track.minPTS;
 
   this.push = function(data) {
-    if (track.minPTS === undefined) {
-      track.minPTS = data.pts;
-    } else {
-      track.minPTS = Math.min(track.minPTS, data.pts);
-    }
-
-    if (track.maxPTS === undefined) {
-      track.maxPTS = data.pts;
-    } else {
-      track.maxPTS = Math.max(track.maxPTS, data.pts);
-    }
+    collectDTSInfo(track, data);
 
     // record the track config
     if (data.nalUnitType === 'seq_parameter_set_rbsp' &&
@@ -1037,6 +1022,8 @@ VideoSegmentStream = function(track) {
     nalUnitsLength = 0;
     mdat = mp4.mdat(data);
 
+    calculateTrackBMDT(track);
+
     moof = mp4.moof(sequenceNumber, [track]);
 
     // it would be great to allocate this array up front instead of
@@ -1049,10 +1036,64 @@ VideoSegmentStream = function(track) {
     boxes.set(moof);
     boxes.set(mdat, moof.byteLength);
 
-    this.trigger('data', boxes);
+    clearDTSInfo(track);
+    emitData(track, boxes);
   };
 };
 VideoSegmentStream.prototype = new muxjs.Stream();
+
+collectDTSInfo = function (track, data) {
+  if (track.minDTS === undefined) {
+    track.minDTS = data.dts;
+  } else {
+    track.minDTS = Math.min(track.minDTS, data.dts);
+  }
+
+  if (track.maxDTS === undefined) {
+    track.maxDTS = data.dts;
+  } else {
+    if (data.dts - track.maxDTS > 100) {
+      track.deltaDTS = data.dts - track.maxDTS;
+    }
+    track.maxDTS = Math.max(track.maxDTS, data.dts);
+  }
+};
+
+clearDTSInfo = function (track) {
+  delete track.minDTS;
+  delete track.maxDTS;
+  delete track.deltaDTS;
+};
+
+calculateTrackBMDT = function (track) {
+  var scale;
+  var nextExpectedBMDT = track.nextExpectedBMDT;
+
+  track.baseMediaDecodeTime = track.minDTS - track.earliestDTS;
+
+  if (nextExpectedBMDT) {
+    // We arbitrarily decide that if the difference is greater than one
+    // second we should not attempt to "pull in" the segment in time
+    if (nextExpectedBMDT < track.baseMediaDecodeTime &&
+      track.baseMediaDecodeTime - nextExpectedBMDT < 90000) {
+      track.baseMediaDecodeTime = nextExpectedBMDT;
+    }
+  }
+
+  if (track.type === 'audio') {
+    console.log('audio', track.earliestDTS, track.minDTS, track.maxDTS, track.deltaDTS, track.endDTS, track.baseMediaDecodeTime);
+    // Audio has a different clock equal to the sampling_rate so we need to
+    // scale the PTS values into the clock rate of the track
+    scale = track.samplerate / 90000;
+    track.baseMediaDecodeTime *= scale;
+    track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
+    console.log('audio >>', (track.samplerate / 90000 * track.earliestDTS), (track.samplerate / 90000 * track.minDTS), (track.samplerate / 90000 * track.maxDTS), track.baseMediaDecodeTime);
+  } else {
+    console.log('video', track.earliestDTS, track.minDTS, track.maxDTS, track.deltaDTS, track.endDTS, track.baseMediaDecodeTime);
+  }
+
+  track.nextExpectedBMDT = track.deltaDTS + track.maxDTS - track.earliestDTS;
+};
 
 /**
  * A Stream that expects MP2T binary data as input and produces
@@ -1065,11 +1106,28 @@ Transmuxer = function() {
     self = this,
     videoTrack,
     audioTrack,
-    earliestPTS,
+    earliestDTS,
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
-    videoSegmentStream, audioSegmentStream;
+    videoSegmentStream, audioSegmentStream,
+
+    emitData = function(track, mediaData) {
+      // append the media data to an init segment
+      var
+        initSegment,
+        segment;
+
+        initSegment = muxjs.mp4.initSegment([track]);
+        segment = new Uint8Array(initSegment.byteLength +
+                                 mediaData.byteLength);
+      segment.set(initSegment);
+      segment.set(mediaData, initSegment.byteLength);
+      self.trigger('data', {
+        type: track.type,
+        data: segment
+      });
+    };
 
   Transmuxer.prototype.init.call(this);
 
@@ -1095,31 +1153,13 @@ Transmuxer = function() {
 
   // hook up the segment streams once track metadata is delivered
   elementaryStream.on('data', function(data) {
-    var triggerData = function(type) {
-      var track = type === 'video' ? videoTrack : audioTrack;
-      return function(mediaData) {
-        // append the media data to an init segment
-        var
-          initSegment,
-          segment;
-
-          initSegment = muxjs.mp4.initSegment([track]);
-          segment = new Uint8Array(initSegment.byteLength +
-                                   mediaData.byteLength);
-        segment.set(initSegment);
-        segment.set(mediaData, initSegment.byteLength);
-        self.trigger('data', {
-          type: type,
-          data: segment
-        });
-      };
-    }, i;
+    var i;
 
     if (data.type === 'audio' || data.type === 'video') {
-      if (earliestPTS === undefined) {
-        earliestPTS = data.pts;
+      if (earliestDTS === undefined) {
+        earliestDTS = data.dts;
       } else {
-        earliestPTS = Math.min(earliestPTS, data.pts);
+        earliestDTS = Math.min(earliestDTS, data.dts);
       }
     }
 
@@ -1132,18 +1172,16 @@ Transmuxer = function() {
         // hook up the video segment stream to the first track with h264 data
         if (data.tracks[i].type === 'video' && !videoSegmentStream) {
           videoTrack = data.tracks[i];
-          videoSegmentStream = new VideoSegmentStream(videoTrack);
+          videoSegmentStream = new VideoSegmentStream(videoTrack, emitData);
           h264Stream.pipe(videoSegmentStream);
-          videoSegmentStream.on('data', triggerData('video'));
           break;
         }
 
         // hook up the audio segment stream to the first track with aac data
         if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
           audioTrack = data.tracks[i];
-          audioSegmentStream = new AudioSegmentStream(audioTrack);
+          audioSegmentStream = new AudioSegmentStream(audioTrack, emitData);
           aacStream.pipe(audioSegmentStream);
-          audioSegmentStream.on('data', triggerData('audio'));
         }
       }
     }
@@ -1151,8 +1189,6 @@ Transmuxer = function() {
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
-    videoSegmentStream = null;
-    audioSegmentStream = null;
     packetStream.push(data);
   };
 
@@ -1160,14 +1196,17 @@ Transmuxer = function() {
   this.flush = function() {
     elementaryStream.flush();
     h264Stream.flush();
+
     if (videoSegmentStream) {
-      videoTrack.earliestPTS = earliestPTS;
+      videoTrack.earliestDTS = earliestDTS;
       videoSegmentStream.flush();
     }
+
     if (audioSegmentStream) {
-      audioTrack.earliestPTS = earliestPTS;
+      audioTrack.earliestDTS = earliestDTS;
       audioSegmentStream.flush();
     }
+
     // Let the consumer know we have finished flushing the buffers
     this.trigger('done');
   };

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -1051,7 +1051,7 @@ module('VideoSegmentStream', {
 test('concatenates NAL units into AVC elementary streams', function() {
   var segment, boxes;
   videoSegmentStream.on('data', function(data) {
-    segment = data;
+    segment = data.boxes;
   });
   videoSegmentStream.push({
     data: new Uint8Array([
@@ -1083,7 +1083,7 @@ test('concatenates NAL units into AVC elementary streams', function() {
 test('infers sample durations from DTS values', function() {
   var segment, boxes, samples;
   videoSegmentStream.on('data', function(data) {
-    segment = data;
+    segment = data.boxes;
   });
   videoSegmentStream.push({
     data: new Uint8Array([0x09, 0x01]),
@@ -1113,7 +1113,7 @@ test('infers sample durations from DTS values', function() {
 test('calculates compositionTimeOffset values from the PTS and DTS', function() {
   var segment, boxes, samples;
   videoSegmentStream.on('data', function(data) {
-    segment = data;
+    segment = data.boxes;
   });
   videoSegmentStream.push({
     data: new Uint8Array([0x09, 0x01]),

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -1043,7 +1043,9 @@ test('can be reset', function() {
 
 module('VideoSegmentStream', {
   setup: function() {
-    videoSegmentStream = new VideoSegmentStream({});
+    var track = {};
+    videoSegmentStream = new VideoSegmentStream(track);
+    videoSegmentStream.track = track;
   }
 });
 
@@ -1142,6 +1144,40 @@ test('calculates compositionTimeOffset values from the PTS and DTS', function() 
   equal(samples[1].compositionTimeOffset, 1, 'calculated compositionTimeOffset');
   equal(samples[2].compositionTimeOffset, 3, 'calculated compositionTimeOffset');
 });
+
+test('calculates baseMediaDecodeTime values from the first DTS ever seen and subsequent segments\' lowest DTS', function() {
+  var segment, boxes, tfdt;
+  videoSegmentStream.on('data', function(data) {
+    segment = data.boxes;
+  });
+
+  videoSegmentStream.track.earliestDTS = 10;
+
+  videoSegmentStream.push({
+    data: new Uint8Array([0x09, 0x01]),
+    nalUnitType: 'access_unit_delimiter_rbsp',
+    dts: 100,
+    pts: 1
+  });
+  videoSegmentStream.push({
+    data: new Uint8Array([0x09, 0x01]),
+    nalUnitType: 'access_unit_delimiter_rbsp',
+    dts: 200,
+    pts: 1
+  });
+  videoSegmentStream.push({
+    data: new Uint8Array([0x09, 0x01]),
+    nalUnitType: 'access_unit_delimiter_rbsp',
+    dts: 300,
+    pts: 1
+  });
+  videoSegmentStream.flush();
+
+  boxes = muxjs.inspectMp4(segment);
+  tfdt = boxes[0].boxes[1].boxes[1];
+  equal(tfdt.baseMediaDecodeTime, 90, 'calculated baseMediaDecodeTime');
+});
+
 module('AAC Stream', {
   setup: function() {
     aacStream = new AacStream();


### PR DESCRIPTION
We need to set the baseMediaDecodeTime so that MSE knows where, in time, it should plop segments