### PR TITLE
Collect captions in the coalesce stream before emitting

### DIFF
--- a/lib/caption-stream.js
+++ b/lib/caption-stream.js
@@ -176,11 +176,11 @@
   // list is not exhaustive. For a more comprehensive listing and
   // semantics see
   // http://www.gpo.gov/fdsys/pkg/CFR-2010-title47-vol1/pdf/CFR-2010-title47-vol1-sec15-119.pdf
-  var PADDING = 0x0000,
-      RESUME_CAPTION_LOADING = 0x1420,
-      ERASE_DISPLAYED_MEMORY = 0x142c,
+  var PADDING                    = 0x0000,
+      RESUME_CAPTION_LOADING     = 0x1420,
+      ERASE_DISPLAYED_MEMORY     = 0x142c,
       ERASE_NON_DISPLAYED_MEMORY = 0x142e,
-      END_OF_CAPTION = 0x142f;
+      END_OF_CAPTION             = 0x142f;
 
   var Cea608Stream = function() {
     Cea608Stream.prototype.init.call(this);

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -17,7 +17,7 @@ var TransportPacketStream, TransportParseStream, ElementaryStream,
     H264Stream, NalByteStream, CoalesceStream;
 
 // Helper functions
-var collectDTSInfo, clearDTSInfo, calculateTrackBaseMediaDecodeTime;
+var collectDtsInfo, clearDtsInfo, calculateTrackBaseMediaDecodeTime;
 
 // constants
 var MP2T_PACKET_LENGTH, H264_STREAM_TYPE, ADTS_STREAM_TYPE,
@@ -497,7 +497,7 @@ AudioSegmentStream = function(track) {
   AudioSegmentStream.prototype.init.call(this);
 
   this.push = function(data) {
-    collectDTSInfo(track, data);
+    collectDtsInfo(track, data);
 
     if (track && track.channelcount === undefined) {
       track.audioobjecttype = data.audioobjecttype;
@@ -549,7 +549,7 @@ AudioSegmentStream = function(track) {
     boxes.set(moof);
     boxes.set(mdat, moof.byteLength);
 
-    clearDTSInfo(track);
+    clearDtsInfo(track);
     this.trigger('data', {track: track, boxes: boxes});
   };
 };
@@ -928,7 +928,7 @@ VideoSegmentStream = function(track) {
   delete track.minPTS;
 
   this.push = function(data) {
-    collectDTSInfo(track, data);
+    collectDtsInfo(track, data);
 
     // record the track config
     if (data.nalUnitType === 'seq_parameter_set_rbsp' &&
@@ -1038,7 +1038,7 @@ VideoSegmentStream = function(track) {
     boxes.set(moof);
     boxes.set(mdat, moof.byteLength);
 
-    clearDTSInfo(track);
+    clearDtsInfo(track);
     this.trigger('data', {track: track, boxes: boxes});
   };
 };
@@ -1049,11 +1049,11 @@ VideoSegmentStream.prototype = new muxjs.Stream();
  * duration for each frame/sample we process in order to calculate
  * the baseMediaDecodeTime
  */
-collectDTSInfo = function (track, data) {
-  if (track.minSegmentDTS === undefined) {
-    track.minSegmentDTS = data.dts;
+collectDtsInfo = function (track, data) {
+  if (track.minSegmentDts === undefined) {
+    track.minSegmentDts = data.dts;
   } else {
-    track.minSegmentDTS = Math.min(track.minSegmentDTS, data.dts);
+    track.minSegmentDts = Math.min(track.minSegmentDts, data.dts);
   }
   if (track.minSegmentPts === undefined) {
     track.minSegmentPts = data.pts;
@@ -1061,18 +1061,18 @@ collectDTSInfo = function (track, data) {
     track.minSegmentPts = Math.min(track.minSegmentPts, data.pts);
   }
 
-  if (track.maxSegmentDTS === undefined) {
-    track.maxSegmentDTS = data.dts;
+  if (track.maxSegmentDts === undefined) {
+    track.maxSegmentDts = data.dts;
   } else {
     // In order to calculate the "duration" of samples we look for
     // the last sample that has a duration longer than an arbitrary
     // value of "100."
     // The reason is that often the last sample has a tiny duration
     // that is not indicative of the true duration of the samples
-    if (data.dts - track.maxSegmentDTS > 100) {
-      track.deltaDTS = data.dts - track.maxSegmentDTS;
+    if (data.dts - track.maxSegmentDts > 100) {
+      track.deltaDts = data.dts - track.maxSegmentDts;
     }
-    track.maxSegmentDTS = Math.max(track.maxSegmentDTS, data.dts);
+    track.maxSegmentDts = Math.max(track.maxSegmentDts, data.dts);
   }
 };
 
@@ -1080,10 +1080,10 @@ collectDTSInfo = function (track, data) {
  * Clear values used to calculate the baseMediaDecodeTime between
  * tracks
  */
-clearDTSInfo = function (track) {
-  delete track.minSegmentDTS;
-  delete track.maxSegmentDTS;
-  delete track.deltaDTS;
+clearDtsInfo = function (track) {
+  delete track.minSegmentDts;
+  delete track.maxSegmentDts;
+  delete track.deltaDts;
 };
 
 /**
@@ -1097,7 +1097,7 @@ calculateTrackBaseMediaDecodeTime = function (track) {
     oneSecondInPTS = 90000, // 90kHz clock
     scale;
 
-  track.baseMediaDecodeTime = track.minSegmentDTS - track.timelineStartDTS;
+  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartDts;
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
@@ -1108,7 +1108,7 @@ calculateTrackBaseMediaDecodeTime = function (track) {
   }
 
   track.expectedBaseMediaDecodeTime =
-    track.deltaDTS + track.maxSegmentDTS - track.timelineStartDTS;
+    track.deltaDts + track.maxSegmentDts - track.timelineStartDts;
 };
 
 /**
@@ -1223,7 +1223,7 @@ Transmuxer = function() {
     self = this,
     videoTrack,
     audioTrack,
-    timelineStartDTS,
+    timelineStartDts,
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
@@ -1264,10 +1264,10 @@ Transmuxer = function() {
     var i;
 
     if (data.type === 'audio' || data.type === 'video') {
-      if (timelineStartDTS === undefined) {
-        timelineStartDTS = data.dts;
+      if (timelineStartDts === undefined) {
+        timelineStartDts = data.dts;
       } else {
-        timelineStartDTS = Math.min(timelineStartDTS, data.dts);
+        timelineStartDts = Math.min(timelineStartDts, data.dts);
       }
     }
 
@@ -1309,12 +1309,12 @@ Transmuxer = function() {
     h264Stream.flush();
 
     if (videoSegmentStream) {
-      videoTrack.timelineStartDTS = timelineStartDTS;
+      videoTrack.timelineStartDts = timelineStartDts;
       videoSegmentStream.flush();
     }
 
     if (audioSegmentStream) {
-      audioTrack.timelineStartDTS = timelineStartDTS;
+      audioTrack.timelineStartDts = timelineStartDts;
       audioSegmentStream.flush();
     }
 

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -1055,6 +1055,11 @@ collectDTSInfo = function (track, data) {
   } else {
     track.minSegmentDTS = Math.min(track.minSegmentDTS, data.dts);
   }
+  if (track.minSegmentPts === undefined) {
+    track.minSegmentPts = data.pts;
+  } else {
+    track.minSegmentPts = Math.min(track.minSegmentPts, data.pts);
+  }
 
   if (track.maxSegmentDTS === undefined) {
     track.maxSegmentDTS = data.dts;
@@ -1118,24 +1123,19 @@ CoalesceStream = function() {
   this.numberOfTracks = 0;
 
   this.pendingTracks = [];
+  this.videoTrack = null;
   this.pendingBoxes = [];
+  this.pendingCaptions = [];
   this.pendingBytes = 0;
-  this.baseMediaDecodeTime = Infinity;
 
   CoalesceStream.prototype.init.call(this);
 
   // Take output from multiple
   this.push = function(output) {
-    // append the media data to an init segment
-    var
-      offset = 0,
-      baseMediaDecodeTime,
-      initSegment,
-      segmentData,
-      segmentType = output.track.type;
-
-    if (this.numberOfTracks > 1) {
-      segmentType = 'combined';
+    // buffer incoming captions until the associated video segment
+    // finishes
+    if (output.text) {
+      return this.pendingCaptions.push(output);
     }
 
     // Add this track to the list of pending tracks and store
@@ -1144,47 +1144,73 @@ CoalesceStream = function() {
     this.pendingTracks.push(output.track);
     this.pendingBoxes.push(output.boxes);
     this.pendingBytes += output.boxes.byteLength;
-    this.baseMediaDecodeTime = Math.min(this.baseMediaDecodeTime,
-                                        output.track.baseMediaDecodeTime);
+    if (output.track.type === 'video') {
+      this.videoTrack = output.track;
+    }
 
     // Once we have enough tracks from the various part of the
     // re-muxing streams we can assemble the final output
     if (this.pendingTracks.length >= this.numberOfTracks) {
-      initSegment = muxjs.mp4.initSegment(this.pendingTracks);
-
-      // Create a new typed array large enough to hold the init
-      // segment and all tracks
-      segmentData = new Uint8Array(initSegment.byteLength +
-                                   this.pendingBytes);
-
-      // Create an init segment containing a moov
-      // and track definitions
-      segmentData.set(initSegment);
-      offset += initSegment.byteLength;
-
-      // Append each moof (one per track) after the init segment
-      for (var i = 0; i < this.pendingBoxes.length; i++) {
-        segmentData.set(this.pendingBoxes[i], offset);
-        offset += this.pendingBoxes[i].byteLength;
-      }
-      baseMediaDecodeTime = this.baseMediaDecodeTime;
-
-      this.pendingTracks.length = 0;
-      this.pendingBoxes.length = 0;
-      this.pendingBytes = 0;
-      this.baseMediaDecodeTime = Infinity;
-
-      // Emit the final segment
-      this.trigger('data', {
-        type: segmentType,
-        baseMediaDecodeTime: baseMediaDecodeTime,
-        data: segmentData
-      });
+      this.flush();
     }
   };
 };
-
 CoalesceStream.prototype = new muxjs.Stream();
+CoalesceStream.prototype.flush = function() {
+  var
+    offset = 0,
+    event = {
+      captions: []
+    },
+    caption,
+    initSegment,
+    i;
+
+  if (this.pendingTracks.length === 1) {
+    event.type = this.pendingTracks[0].type;
+  } else {
+    event.type = 'combined';
+  }
+
+  initSegment = muxjs.mp4.initSegment(this.pendingTracks);
+
+  // Create a new typed array large enough to hold the init
+  // segment and all tracks
+  event.data = new Uint8Array(initSegment.byteLength +
+                              this.pendingBytes);
+
+  // Create an init segment containing a moov
+  // and track definitions
+  event.data.set(initSegment);
+  offset += initSegment.byteLength;
+
+  // Append each moof+mdat (one per track) after the init segment
+  for (i = 0; i < this.pendingBoxes.length; i++) {
+    event.data.set(this.pendingBoxes[i], offset);
+    offset += this.pendingBoxes[i].byteLength;
+  }
+
+  // Translate caption PTS times into second offsets into the
+  // video timeline for the segment
+  for (i = 0; i < this.pendingCaptions.length; i++) {
+    caption = this.pendingCaptions[i];
+    caption.startTime = caption.startPts - this.videoTrack.minSegmentPts;
+    caption.startTime /= 90e3;
+    caption.endTime = caption.endPts - this.videoTrack.minSegmentPts;
+    caption.endTime /= 90e3;
+    event.captions.push(caption);
+  }
+
+  // Reset stream state
+  this.pendingTracks.length = 0;
+  this.videoTrack = null;
+  this.pendingBoxes.length = 0;
+  this.pendingCaptions.length = 0;
+  this.pendingBytes = 0;
+
+  // Emit the final segment
+  this.trigger('data', event);
+};
 
 /**
  * A Stream that expects MP2T binary data as input and produces
@@ -1201,7 +1227,7 @@ Transmuxer = function() {
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
-    videoSegmentStream, audioSegmentStream,
+    videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream;
 
   Transmuxer.prototype.init.call(this);
@@ -1228,8 +1254,9 @@ Transmuxer = function() {
   elementaryStream.pipe(this.metadataStream);
   // if CEA-708 parsing is available, hook up a caption stream
   if (muxjs.mp2t.CaptionStream) {
-    this.captionStream = new muxjs.mp2t.CaptionStream();
-    h264Stream.pipe(this.captionStream);
+    captionStream = new muxjs.mp2t.CaptionStream();
+    h264Stream.pipe(captionStream)
+      .pipe(coalesceStream);
   }
 
   // hook up the segment streams once track metadata is delivered

--- a/test/caption-stream-test.js
+++ b/test/caption-stream-test.js
@@ -75,8 +75,10 @@
     var transmuxer = new muxjs.mp2t.Transmuxer(),
         captions = [];
 
-    transmuxer.captionStream.on('data', function(caption) {
-      captions.push(caption);
+    transmuxer.on('data', function(data) {
+      if (data.captions) {
+        captions = captions.concat(data.captions);
+      }
     });
 
     transmuxer.push(window.sintelCaptions);
@@ -85,6 +87,8 @@
     equal(captions.length, 2, 'parsed two captions');
     equal(captions[0].text.indexOf('ASUKA'), 0, 'parsed the start of the first caption');
     ok(captions[0].text.indexOf('Japanese') > 0, 'parsed the end of the first caption');
+    equal(captions[0].startTime, 1, 'parsed the start time');
+    equal(captions[0].endTime, 4, 'parsed the end time');
   });
 
   var cea608Stream;

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -1216,7 +1216,7 @@ test('calculates baseMediaDecodeTime values from the first DTS ever seen and sub
     segment = data.boxes;
   });
 
-  videoSegmentStream.track.timelineStartDTS = 10;
+  videoSegmentStream.track.timelineStartDts = 10;
 
   videoSegmentStream.push({
     data: new Uint8Array([0x09, 0x01]),


### PR DESCRIPTION
Captions require information about the start time of their associated segment in order to properly place them in the media timeline and that information is not available until after the entire segment is parsed. Buffer captions in the coalesce stream until the segment is ready and then calculate start and end times so that downstream consumers don't have to do it themselves.