### PR TITLE
Add roll-up CEA-608 captions mode

### DIFF
--- a/lib/caption-stream.js
+++ b/lib/caption-stream.js
@@ -177,17 +177,48 @@
   // semantics see
   // http://www.gpo.gov/fdsys/pkg/CFR-2010-title47-vol1/pdf/CFR-2010-title47-vol1-sec15-119.pdf
   var PADDING                    = 0x0000,
+
+      // Pop-on Mode
       RESUME_CAPTION_LOADING     = 0x1420,
+      END_OF_CAPTION             = 0x142f,
+
+      // Paint-on Mode
+      RESUME_DIRECT_CAPTIONING   = 0x1429,
+
+      // Roll-up Mode
+      ROLL_UP_2_ROWS             = 0x1425,
+      ROLL_UP_3_ROWS             = 0x1426,
+      ROLL_UP_4_ROWS             = 0x1427,
+      CARRIAGE_RETURN            = 0x142d,
+
+      // Erasure
       ERASE_DISPLAYED_MEMORY     = 0x142c,
-      ERASE_NON_DISPLAYED_MEMORY = 0x142e,
-      END_OF_CAPTION             = 0x142f;
+      ERASE_NON_DISPLAYED_MEMORY = 0x142e;
+
+  // the index of the last row in a CEA-608 display buffer
+  var BOTTOM_ROW = 14;
+  // CEA-608 captions are rendered onto a 34x15 matrix of character
+  // cells. The "bottom" row is the last element in the outer array.
+  var createDisplayBuffer = function() {
+    var result = [], i = BOTTOM_ROW + 1;
+    while (i--) {
+      result.push('');
+    }
+    return result;
+  };
 
   var Cea608Stream = function() {
     Cea608Stream.prototype.init.call(this);
 
+    this.mode_ = 'popOn';
+    // When in roll-up mode, the index of the last row that will
+    // actually display captions. If a caption is shifted to a row
+    // with a lower index than this, it is cleared from the display
+    // buffer
+    this.topRow_ = 0;
     this.startPts_ = 0;
-    this.displayed_ = '';
-    this.nonDisplayed_ = '';
+    this.displayed_ = createDisplayBuffer();
+    this.nonDisplayed_ = createDisplayBuffer();
 
     this.push = function(packet) {
       var data, swap, charCode;
@@ -197,18 +228,13 @@
       switch (data) {
       case PADDING:
         break;
+
       case RESUME_CAPTION_LOADING:
-        break;
-      case ERASE_DISPLAYED_MEMORY:
-        this.finishDisplayed(packet.pts);
-        this.displayed_ = '';
-        break;
-      case ERASE_NON_DISPLAYED_MEMORY:
-        this.nonDisplayed_ = '';
+        this.mode_ = 'popOn';
         break;
       case END_OF_CAPTION:
         // if a caption was being displayed, it's gone now
-        this.finishDisplayed(packet.pts);
+        this.flushDisplayed(packet.pts);
 
         // flip memory
         swap = this.displayed_;
@@ -218,6 +244,37 @@
         // start measuring the time to display the caption
         this.startPts_ = packet.pts;
         break;
+
+      case RESUME_DIRECT_CAPTIONING:
+        console.log('paint-on');
+        break;
+
+      case ROLL_UP_2_ROWS:
+        this.topRow_ = BOTTOM_ROW - 1;
+        this.mode_ = 'rollUp';
+        break;
+      case ROLL_UP_3_ROWS:
+        this.topRow_ = BOTTOM_ROW - 2;
+        this.mode_ = 'rollUp';
+        break;
+      case ROLL_UP_4_ROWS:
+        this.topRow_ = BOTTOM_ROW - 3;
+        this.mode_ = 'rollUp';
+        break;
+      case CARRIAGE_RETURN:
+        this.flushDisplayed(packet.pts);
+        this.shiftRowsUp_();
+        this.startPts_ = packet.pts;
+        break;
+
+      case ERASE_DISPLAYED_MEMORY:
+        this.flushDisplayed(packet.pts);
+        this.displayed_ = createDisplayBuffer();
+        break;
+      case ERASE_NON_DISPLAYED_MEMORY:
+        this.nonDisplayed_ = createDisplayBuffer();
+        break;
+
       default:
         charCode = data >>> 8;
 
@@ -226,28 +283,71 @@
           return;
         }
 
-        // buffer characters
-        charCode = BASIC_CHARACTER_TRANSLATION[charCode] || charCode;
-        this.nonDisplayed_ += String.fromCharCode(charCode);
-
-        charCode = data & 0xff;
-        charCode = BASIC_CHARACTER_TRANSLATION[charCode] || charCode;
-        this.nonDisplayed_ += String.fromCharCode(charCode);
+        // character handling is dependent on the current mode
+        this[this.mode_](packet.pts, charCode, data & 0xff);
         break;
       }
     };
   };
   Cea608Stream.prototype = new muxjs.Stream();
   // Trigger a cue point that captures the current state of the
-  // displayed memory.
-  Cea608Stream.prototype.finishDisplayed = function(pts) {
-    if (this.displayed_.length) {
-      this.trigger('data', {
-        startPts: this.startPts_,
-        endPts: pts,
-        text: this.displayed_
-      });
+  // display buffer
+  Cea608Stream.prototype.flushDisplayed = function(pts) {
+    var row, i;
+
+    for (i = 0; i < this.displayed_.length; i++) {
+      row = this.displayed_[i];
+      if (row.length) {
+        this.trigger('data', {
+          startPts: this.startPts_,
+          endPts: pts,
+          text: row
+        });
+      }
     }
+  };
+
+  // Mode Implementations
+  Cea608Stream.prototype.popOn = function(pts, char0, char1) {
+    var baseRow = this.nonDisplayed_[BOTTOM_ROW];
+
+    // buffer characters
+    char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
+    baseRow += String.fromCharCode(char0);
+
+    char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
+    baseRow += String.fromCharCode(char1);
+    this.nonDisplayed_[BOTTOM_ROW] = baseRow;
+  };
+  Cea608Stream.prototype.rollUp = function(pts, char0, char1) {
+    var baseRow = this.displayed_[BOTTOM_ROW];
+    if (baseRow === '') {
+      // we're starting to buffer new display input, so flush out the
+      // current display
+      this.flushDisplayed(pts);
+
+      this.startPts_ = pts;
+    }
+
+    char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
+    baseRow += String.fromCharCode(char0);
+
+    char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
+    baseRow += String.fromCharCode(char1);
+    this.displayed_[BOTTOM_ROW] = baseRow;
+  };
+  Cea608Stream.prototype.shiftRowsUp_ = function() {
+    var i;
+    // clear out inactive rows
+    for (i = 0; i < this.topRow_; i++) {
+      this.displayed_[i] = '';
+    }
+    // shift displayed rows up
+    for (i = this.topRow_; i < BOTTOM_ROW; i++) {
+      this.displayed_[i] = this.displayed_[i + 1];
+    }
+    // clear out the bottom row
+    this.displayed_[BOTTOM_ROW] = '';
   };
 
   // exports

--- a/lib/caption-stream.js
+++ b/lib/caption-stream.js
@@ -182,9 +182,6 @@
       RESUME_CAPTION_LOADING     = 0x1420,
       END_OF_CAPTION             = 0x142f,
 
-      // Paint-on Mode
-      RESUME_DIRECT_CAPTIONING   = 0x1429,
-
       // Roll-up Mode
       ROLL_UP_2_ROWS             = 0x1425,
       ROLL_UP_3_ROWS             = 0x1426,
@@ -243,10 +240,6 @@
 
         // start measuring the time to display the caption
         this.startPts_ = packet.pts;
-        break;
-
-      case RESUME_DIRECT_CAPTIONING:
-        console.log('paint-on');
         break;
 
       case ROLL_UP_2_ROWS:


### PR DESCRIPTION
Shift to a data model in Cea608Stream that more accurately simulates the theoretical captions decoder from the spec. Use the new model to implement roll-up captions mode with 2, 3, and 4 row support.