### PR TITLE
Support the backspace command code

### DIFF
--- a/lib/caption-stream.js
+++ b/lib/caption-stream.js
@@ -189,6 +189,7 @@
       CARRIAGE_RETURN            = 0x142d,
 
       // Erasure
+      BACKSPACE                  = 0x1421,
       ERASE_DISPLAYED_MEMORY     = 0x142c,
       ERASE_NON_DISPLAYED_MEMORY = 0x142e;
 
@@ -260,6 +261,13 @@
         this.startPts_ = packet.pts;
         break;
 
+      case BACKSPACE:
+        if (this.mode_ === 'popOn') {
+          this.nonDisplayed_[BOTTOM_ROW] = this.nonDisplayed_[BOTTOM_ROW].slice(0, -1);
+        } else {
+          this.displayed_[BOTTOM_ROW] = this.displayed_[BOTTOM_ROW].slice(0, -1);
+        }
+        break;
       case ERASE_DISPLAYED_MEMORY:
         this.flushDisplayed(packet.pts);
         this.displayed_ = createDisplayBuffer();

--- a/test/caption-stream-test.js
+++ b/test/caption-stream-test.js
@@ -93,6 +93,16 @@
 
   var cea608Stream;
 
+  // Returns a ccData byte-pair for a two character string. That is,
+  // it converts a string like 'hi' into the two-byte number that
+  // would be parsed back as 'hi' when provided as ccData.
+  var characters = function(text) {
+    if (text.length !== 2) {
+      throw new Error('ccdata must be specified two characters at a time');
+    }
+    return (text.charCodeAt(0) << 8) | text.charCodeAt(1);
+  };
+
   module('CEA 608 Stream', {
     beforeEach: function() {
       cea608Stream = new muxjs.mp2t.Cea608Stream();
@@ -142,7 +152,7 @@
        // RCL, resume caption loading
       { ccData: 0x1420 },
       // 'hi'
-      { ccData: ('h'.charCodeAt(0) << 8) | 'i'.charCodeAt(0) },
+      { ccData: characters('hi') },
       // EOC, End of Caption. Finished transmitting, begin display
       { pts: 1000, ccData: 0x142f },
       // EOC, End of Caption. End display
@@ -173,17 +183,17 @@
        // RCL, resume caption loading
       { ccData: 0x1420 },
       // '01'
-      { ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0) },
+      { ccData: characters('01') },
       // EOC, End of Caption. Finished transmitting, display '01'
       { pts: 1 * 1000, ccData: 0x142f },
       // EDM, Erase Displayed Memory
       { pts: 1.5 * 1000, ccData: 0x142c },
       // '23'
-      { ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0) },
+      { ccData: characters('23') },
       // EOC, End of Caption. Display '23'
       { pts: 2 * 1000, ccData: 0x142f },
       // '34'
-      { ccData: ('3'.charCodeAt(0) << 8) | '4'.charCodeAt(0) },
+      { ccData: characters('34') },
       // EOC, End of Caption. Display '34'
       { pts: 3 * 1000, ccData: 0x142f },
       // EOC, End of Caption
@@ -226,12 +236,12 @@
     cea608Stream.push({ ccData: 0x1420 });
     // '01'
     cea608Stream.push({
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // backspace
     cea608Stream.push({ ccData: 0x1421 });
     cea608Stream.push({
-      ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0)
+      ccData: characters('23')
     });
     // EOC, End of Caption
     cea608Stream.push({ pts: 1 * 1000, ccData: 0x142f });
@@ -264,10 +274,10 @@
        // RCL, resume caption loading
       { ccData: 0x1420 },
       // '01'
-      { ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0) },
+      { ccData: characters('01') },
       // ENM, Erase Non-Displayed Memory
       { ccData: 0x142e },
-      { ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0) },
+      { ccData: characters('23') },
       // EOC, End of Caption. Finished transmitting, display '23'
       { pts: 1 * 1000, ccData: 0x142f },
       // EOC, End of Caption
@@ -297,7 +307,7 @@
       // a row-9 indent 28 underline, which is not supported
       { ccData: 0x1f7f },
       // '01'
-      { ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0) },
+      { ccData: characters('01') },
       // EOC, End of Caption
       { pts: 1 * 1000, ccData: 0x142f },
       // EOC, End of Caption
@@ -329,7 +339,7 @@
     // '01'
     cea608Stream.push({
       pts: 1 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 3 * 1000, ccData: 0x142d });
@@ -347,7 +357,7 @@
     // '23'
     cea608Stream.push({
       pts: 4 * 1000,
-      ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0)
+      ccData: characters('23')
     });
     // CR
     cea608Stream.push({ pts: 5 * 1000, ccData: 0x142d });
@@ -380,7 +390,7 @@
     // '01'
     cea608Stream.push({
       pts: 0 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 1 * 1000, ccData: 0x142d });
@@ -395,7 +405,7 @@
     // '23'
     cea608Stream.push({
       pts: 2 * 1000,
-      ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0)
+      ccData: characters('23')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 3 * 1000, ccData: 0x142d });
@@ -420,7 +430,7 @@
     // '45'
     cea608Stream.push({
       pts: 4 * 1000,
-      ccData: ('4'.charCodeAt(0) << 8) | '5'.charCodeAt(0)
+      ccData: characters('45')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 5 * 1000, ccData: 0x142d });
@@ -453,7 +463,7 @@
     // '01'
     cea608Stream.push({
       pts: 0 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 1 * 1000, ccData: 0x142d });
@@ -489,13 +499,13 @@
     // '01'
     cea608Stream.push({
       pts: 0 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // backspace
     cea608Stream.push({ ccData: 0x1421 });
     cea608Stream.push({
       pts: 1 * 1000,
-      ccData: ('2'.charCodeAt(0) << 8) | '3'.charCodeAt(0)
+      ccData: characters('23')
     });
     // CR, carriage return
     cea608Stream.push({ pts: 1 * 1000, ccData: 0x142d });
@@ -515,7 +525,7 @@
     // '01'
     cea608Stream.push({
       pts: 0 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // backspace
     cea608Stream.push({ ccData: 0x1421 });
@@ -538,7 +548,7 @@
     // '01'
     cea608Stream.push({
       pts: 0 * 1000,
-      ccData: ('0'.charCodeAt(0) << 8) | '1'.charCodeAt(0)
+      ccData: characters('01')
     });
     // backspace
     cea608Stream.push({ ccData: 0x1421 });


### PR DESCRIPTION
In pop-on and roll-up modes, move the "cursor" back one cell and clear the character that is traversed when a backspace is received. We don't yet support any cursor-movement commands besides this one so the backspace is always applied to the last position in the base row for the current captioning mode.