### PR TITLE
Selective output

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -14,6 +14,12 @@
   <link rel="stylesheet" href="css/main.css">
 
   <script src="js/vendor/modernizr-2.6.2.min.js"></script>
+  <style>
+    fieldset {
+      padding: 10px;
+      border: 1px solid #ccc;
+    }
+  </style>
 </head>
 <body>
   <!--[if lt IE 7]>
@@ -52,13 +58,28 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
               the player on this page.
             </legend>
             <fieldset>
-              <input id="original-active" type=radio name=active checked value="original">
-              <label>
-                Your original MP2T segment:
-                <input type="file" id="original">
-              </label>
+              <legend>M2TS Input</legend>
+              <div>
+                <input id="original-active" type=radio name=active checked value="original">
+                <label>
+                  Your original MP2T segment:
+                  <input type="file" id="original">
+                </label>
+              </div>
+              <div>
+                <label><input id="combined-output" type=checkbox name=combined checked value="combined">&nbsp;Remux output into a single output?
+                </label>
+              </div>
+              <div>
+                Otherwise, output only:&nbsp;
+                <label><input id="video-output" type=radio name=output disabled checked value="video">&nbsp;Video
+                </label>
+                <label><input id="audio-output" type=radio name=output disabled checked value="audio">&nbsp;Audio
+                </label>
+              </div>
             </fieldset>
             <fieldset>
+              <legend>MP4 Input</legend>
               <input id="working-active" type=radio name=active value="working">
               <label>
                 A working, MP4 version of the underlying stream
@@ -66,10 +87,12 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
                 <input type="file" id="working">
               </label>
             </fieldset>
-            <label>
-              Codecs:
-              <input id="codecs" type="text" value="avc1.64001f,mp4a.40.5">
-            </label>
+            <div>
+              <label>
+                Codecs:
+                <input id="codecs" type="text" value="avc1.64001f,mp4a.40.5">
+              </label>
+            </div>
           </form>
         </section>
         <section id="video-place">
@@ -130,12 +153,10 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
         vjsBoxes = document.querySelector('.vjs-boxes'),
         workingBoxes = document.querySelector('.working-boxes'),
 
-        video = document.createElement('video'),
-        mediaSource = new MediaSource(),
+        video,
+        mediaSource,
         logevent,
         prepareSourceBuffer;
-
-        document.querySelector('#video-place').appendChild(video);
 
         logevent = function(event) {
           console.log(event.type);
@@ -163,36 +184,56 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       comparison.innerHTML = diff;
     };
 
-    prepareSourceBuffer = function() {
-      var buffer, codecs;
-      if (window.vjsBuffer) {
-        return;
+    prepareSourceBuffer = function(combined, outputType, callback) {
+      var
+        buffer,
+        codecs,
+        codecsArray;
+
+      if (typeof combined === 'function') {
+        callback = combined;
+        combined = true;
       }
 
+      video = document.createElement('video');
+      video.controls = true;
+      mediaSource = new MediaSource();
+      video.src = URL.createObjectURL(mediaSource);
+      window.vjsVideo = video;
+      window.vjsMediaSource = mediaSource;
+      document.querySelector('#video-place').innerHTML = '';
+      document.querySelector('#video-place').appendChild(video);
+
+      mediaSource.addEventListener('error', logevent);
+      mediaSource.addEventListener('opened', logevent);
+      mediaSource.addEventListener('closed', logevent);
+      mediaSource.addEventListener('sourceended', logevent);
+
       codecs = document.querySelector('#codecs');
-      codecs.disabled = 'true'
+      codecsArray = codecs.value.split(',');
 
-      buffer = mediaSource.addSourceBuffer('video/mp4;codecs="' + codecs.value + '"');
-      buffer.addEventListener('updatestart', logevent);
-      buffer.addEventListener('updateend', logevent);
-      buffer.addEventListener('error', logevent);
-      window.vjsBuffer = buffer;
+      mediaSource.addEventListener('sourceopen', function () {
+        if (combined) {
+          buffer = mediaSource.addSourceBuffer('video/mp4;codecs="' + codecs.value + '"');
+        } else if (outputType === 'video') {
+          buffer = mediaSource.addSourceBuffer('video/mp4;codecs="' + codecsArray[0] + '"');
+        } else if (outputType === 'audio') {
+          buffer = mediaSource.addSourceBuffer('audio/mp4;codecs="' + (codecsArray[1] ||codecsArray[0]) + '"');
+        }
+
+        buffer.addEventListener('updatestart', logevent);
+        buffer.addEventListener('updateend', logevent);
+        buffer.addEventListener('error', logevent);
+        window.vjsBuffer = buffer;
+
+        video.addEventListener('error', logevent);
+        video.addEventListener('error', function() {
+          document.getElementById('video-place').classList.add('error');
+        });
+
+        return callback();
+      });
     };
-
-    video.controls = true;
-    window.vjsVideo = video;
-    window.vjsMediaSource = mediaSource;
-
-    mediaSource.addEventListener('error', logevent);
-    mediaSource.addEventListener('opened', logevent);
-    mediaSource.addEventListener('closed', logevent);
-    mediaSource.addEventListener('sourceended', logevent);
-
-    video.src = URL.createObjectURL(mediaSource);
-    video.addEventListener('error', logevent);
-    video.addEventListener('error', function() {
-      document.getElementById('video-place').classList.add('error');
-    });
 
     original.addEventListener('change', function() {
       var reader = new FileReader();
@@ -204,18 +245,33 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
 
       reader.addEventListener('loadend', function() {
         var segment = new Uint8Array(reader.result),
-            transmuxer = new muxjs.mp2t.Transmuxer(),
+            combined = document.querySelector('#combined-output').checked,
+            outputType = document.querySelector('input[name="output"]:checked').value,
+            transmuxer,
             remuxedSegments = [],
             remuxedBytesLength = 0,
             bytes,
             i, j;
 
-        prepareSourceBuffer();
+        if (combined) {
+            transmuxer = new muxjs.mp2t.Transmuxer();
+        } else {
+            transmuxer = new muxjs.mp2t.Transmuxer({remux: false});
+        }
+
+        if (document.querySelector('#original-active').checked) {
+          prepareSourceBuffer(combined, outputType, function () {
+            window.vjsBuffer.appendBuffer(bytes);
+            video.play();
+          });
+        }
 
         // transmux the MPEG-TS data to BMFF segments
         transmuxer.on('data', function(segment) {
-          remuxedSegments.push(segment);
-          remuxedBytesLength += segment.data.byteLength;
+          if (combined || segment.type === outputType) {
+            remuxedSegments.push(segment);
+            remuxedBytesLength += segment.data.byteLength;
+          }
         });
 
         transmuxer.push(segment);
@@ -232,11 +288,6 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
         console.log('transmuxed', vjsParsed);
         diffParsed();
 
-        if (document.querySelector('#original-active').checked) {
-          window.vjsBuffer.appendBuffer(bytes);
-          video.play();
-        }
-
         // clear old box info
         vjsBoxes.innerHTML = muxjs.textifyMp4(vjsParsed, null, ' ');
       });
@@ -249,7 +300,12 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       reader.addEventListener('loadend', function() {
         var bytes = new Uint8Array(reader.result);
 
-        prepareSourceBuffer();
+        if (document.querySelector('#working-active').checked) {
+          prepareSourceBuffer(function() {
+            window.vjsBuffer.appendBuffer(bytes);
+            video.play();
+          });
+        }
 
         workingBytes = bytes;
         workingParsed = muxjs.inspectMp4(bytes);
@@ -258,14 +314,15 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
 
         // clear old box info
         workingBoxes.innerHTML = muxjs.textifyMp4(workingParsed, null, ' ');
-
-        if (document.querySelector('#working-active').checked) {
-          window.vjsBuffer.appendBuffer(bytes);
-          video.play();
-        }
       });
       reader.readAsArrayBuffer(this.files[0]);
     }, false);
+    document.querySelector('#combined-output').addEventListener('change', function () {
+        Array.prototype.slice.call(document.querySelectorAll('[name="output"'))
+          .forEach(function (el) {
+            el.disabled = this.checked;
+          }, this);
+    });
   </script>
 </body>
 </html>

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -1137,11 +1137,17 @@ calculateTrackBaseMediaDecodeTime = function (track) {
  * into a single output segment for MSE. Also supports audio-only
  * and video-only streams.
  */
-CoalesceStream = function() {
+CoalesceStream = function(options) {
   // Number of Tracks per output segment
   // If greater than 1, we combine multiple
   // tracks into a single segment
   this.numberOfTracks = 0;
+
+  if (typeof options.remux !== 'undefined') {
+    this.remuxTracks = !!options.remux;
+  } else {
+    this.remuxTracks = true;
+  }
 
   this.pendingTracks = [];
   this.videoTrack = null;
@@ -1171,7 +1177,7 @@ CoalesceStream = function() {
 
     // Once we have enough tracks from the various part of the
     // re-muxing streams we can assemble the final output
-    if (this.pendingTracks.length >= this.numberOfTracks) {
+    if (!this.remuxTracks || this.pendingTracks.length >= this.numberOfTracks) {
       this.flush();
     }
   };
@@ -1239,7 +1245,7 @@ CoalesceStream.prototype.flush = function() {
  * Extension (MSE) implementations that support the ISO BMFF byte
  * stream format, like Chrome.
  */
-Transmuxer = function() {
+Transmuxer = function(options) {
   var
     self = this,
     videoTrack,
@@ -1252,6 +1258,7 @@ Transmuxer = function() {
     coalesceStream;
 
   Transmuxer.prototype.init.call(this);
+  options = options || {};
 
   // set up the parsing pipeline
   packetStream = new TransportPacketStream();
@@ -1259,7 +1266,7 @@ Transmuxer = function() {
   elementaryStream = new ElementaryStream();
   aacStream = new AacStream();
   h264Stream = new H264Stream();
-  coalesceStream = new CoalesceStream(this);
+  coalesceStream = new CoalesceStream(options);
 
   // expose the metadata stream
   this.metadataStream = new muxjs.mp2t.MetadataStream();


### PR DESCRIPTION
Transmuxer debugging page now has changes that allow for greater debugging options by enabling the user to force the transmuxer to output only audio or only video segments. Helps you narrow down which of the two segment types is causing a problem with MSE.

Required changes the transmuxer to support non-remuxed output. Added tests to verify that the output from the transmuxer can be specified with an options-object at creation.